### PR TITLE
Add a custom event that fires once the ThreeJS viewer is accessible.

### DIFF
--- a/ros-rviz.html
+++ b/ros-rviz.html
@@ -246,6 +246,9 @@ Example:
         this.addEventListener('iron-resize', function() {
           that.resize();
         });
+        this.fire('viewerConstructed', {
+          viewer: this._viewer,
+        });
       },
 
       /**


### PR DESCRIPTION
I require direct access to the renderer in unrelated code, but since ros-rviz owns the scene, I cannot get to it until it is done loading. The guarantees given by Polymer on the loading order are not sufficient for my use case.