### PR TITLE
Changed websocketUrl to url in ros-rviz-global-options

### DIFF
--- a/ros-rviz-global-options.html
+++ b/ros-rviz-global-options.html
@@ -54,7 +54,7 @@
         if (!this.globalOptions.fixedFrame) {
           this.set('globalOptions.fixedFrame', '/base_link');
         }
-        if (!this.globalOptions.websocketUrl) {
+        if (!this.globalOptions.url) {
           var hostname = window.location.hostname;
           var protocol = 'ws:';
           if (window.location.protocol === 'https:') {


### PR DESCRIPTION
With this change, the correct websocket url is displayed in the global options.