### PR TITLE
Adding ros-rviz-image component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "iron-collapse": "PolymerElements/iron-collapse#^2.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
     "iron-icons": "PolymerElements/iron-icons#^2.0.0",
+    "iron-image": "PolymerElements/iron-image#^2.0.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^2.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^2.0.1",
     "paper-drawer-panel": "PolymerElements/paper-drawer-panel#^2.0.0",

--- a/ros-rviz-display.html
+++ b/ros-rviz-display.html
@@ -8,6 +8,7 @@
 <link rel="import" href="imports.html">
 <link rel="import" href="ros-rviz-depth-cloud.html">
 <link rel="import" href="ros-rviz-grid.html">
+<link rel="import" href="ros-rviz-image.html">
 <link rel="import" href="ros-rviz-interactive-markers.html">
 <link rel="import" href="ros-rviz-marker-array.html">
 <link rel="import" href="ros-rviz-markers.html">
@@ -85,6 +86,17 @@
           tf-client="{{tfClient}}"
           viewer="{{viewer}}"
         ></ros-rviz-depth-cloud>
+      </template>
+      <template is="dom-if" if="{{_typeIs('image', type)}}" restamp="true">
+        <ros-rviz-image id="display"
+          global-options="{{globalOptions}}"
+          is-shown="{{isShown}}"
+          param="{{options.param}}"
+          ros="{{ros}}"
+          tf-client="{{tfClient}}"
+          topic="{{options.topic}}"
+          viewer="{{viewer}}"
+        ></ros-rviz-image>
       </template>
       <template is="dom-if" if="{{_typeIs('interactiveMarkers', type)}}" restamp="true">
         <ros-rviz-interactive-markers id="display"

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -15,7 +15,7 @@
       </paper-listbox>
     </paper-dropdown-menu>
     <div style="position: relative;">
-      <div id="canvas_div" style="position: fixed; z-index: 9; border: 1px solid; background-color: black;">
+      <div id="canvas_div" style="position: fixed; z-index: 9; background-color: transparent;" title="[[topic]]">
         <canvas id="xy_image" width="280px;" height="280px;"/>
       </div>
     </div>

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -1,0 +1,110 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-image/iron-image.html">
+<link rel="import" href="../paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="imports.html">
+
+<dom-module id="ros-rviz-image">
+  <template>
+    <paper-input label="Image topic" value="{{topic}}"></paper-input>
+    <paper-checkbox checked="{{continuous}}">Continuously update</paper-checkbox>
+    <paper-input label="Transport hints" value="{{transport_hints}}"></paper-input>
+    <iron-image id="xy_image" src="[[image_source]]" alt="iron-image" ></iron-image>
+  </template>
+  <script>
+    Polymer({
+      is: 'ros-rviz-image',
+
+      properties: {
+        name: {
+          type: String,
+          value: 'Image',
+        },
+        topic: {
+          type: String,
+          value: '/camera/image/compressed',
+          notify: true,
+        },
+        continuous: {
+          type: Boolean,
+          value: true,
+          notify: true,
+        },
+        image_source: {
+          type: String,
+          value: '',
+        },
+        transport_hints: {
+          type: String,
+          value: 'compressed',
+          notify: true,
+        },
+        globalOptions: Object,
+        isShown: Boolean,
+        ros: Object,
+        tfClient: Object,
+        viewer: Object,
+      },
+
+      observers: [
+        '_optionsChanged(viewer, topic, continuous, transport_hints, ros)',
+      ],
+
+      destroy: function() {
+        // Nothing to destroy.
+      },
+
+      hide: function() {
+        if (this._imageTopic) {
+          this._imageTopic.unsubscribe();
+          this._imageTopic = null;
+        }
+      },
+
+      show: function() {
+        if (this.viewer && this.isShown) {
+          if (!this._imageTopic) {
+            this._updateDisplay();
+          }
+        }
+      },
+
+      _optionsChanged: function(viewer, topic, continuous, transport_hints, ros) {
+        this.hide();
+        this._updateDisplay();
+        this.show();
+      },
+
+      _updateDisplay: function(callback) {
+        console.log('Image updating display')
+        var that = this;
+
+        if (!(this.ros && this.viewer && this.topic &&
+             (this.continuous || this.continuous === false) &&
+             (this.transport_hints))) {
+          return;
+        }
+        if (this._imageTopic) {
+          this._imageTopic.unsubscribe();
+        }
+
+        console.log('Creating image topic')
+        this._imageTopic = new ROSLIB.Topic({
+            ros : this.ros,
+            name : this.topic,
+            messageType : 'sensor_msgs/CompressedImage'
+        });
+
+        this._imageTopic.subscribe(function(message) {
+          console.log('Received message on image viewer');
+          var imagedata = "data:image/jpg;base64," + message.data;
+          that._setImageSource(imagedata);
+        });
+      },
+
+      _setImageSource: function(data) {
+        this.image_source = data
+      },
+    });
+  </script>
+</dom-module>

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-image/iron-image.html">
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-input/paper-input.html">
@@ -9,13 +8,13 @@
 <dom-module id="ros-rviz-image">
   <template>
     <paper-input label="Image topic" value="{{topic}}"></paper-input>
-    <paper-dropdown-menu id="transport_hints_list" label="Transport hints" on-iron-select="transportHintSelected">
+    <paper-dropdown-menu id="transport_hints_dropdown" label="Transport hints" on-iron-select="transportHintSelected">
       <paper-listbox slot="dropdown-content" class="dropdown-content" selected="0">
         <paper-item>Compressed</paper-item>
         <paper-item>CompressedDepth</paper-item>
       </paper-listbox>
     </paper-dropdown-menu>
-    <iron-image id="xy_image" src="[[image_source]]" alt="No image"/>
+    <canvas id="xy_image" width="280px;" height="280px;"/>
   </template>
   <script>
     const _transportHints = {
@@ -36,10 +35,6 @@
           value: '/camera/image',
           notify: true,
         },
-        image_source: {
-          type: String,
-          value: '',
-        },
         transport_hints: {
           type: String,
           value: 'Compressed',
@@ -56,7 +51,7 @@
       ],
 
       transportHintSelected: function(e) {
-        this.transport_hints = this.$.transport_hints_list.selectedItemLabel;
+        this.transport_hints = this.$.transport_hints_dropdown.selectedItemLabel;
         this._optionsChanged();
       },
 
@@ -86,7 +81,9 @@
       },
 
       _updateDisplay: function(callback) {
-        var that = this;
+        const that = this;
+        const canvas = this.$.xy_image;
+        const context = canvas.getContext('2d');
 
         if (!(this.ros && this.viewer && this.topic &&
              (this.transport_hints))) {
@@ -102,23 +99,26 @@
             messageType : _transportHints[this.transport_hints].type
         });
 
-        this._imageTopic.subscribe(function(message) {
-          console.log('Received image');
-          if (!that.$.xy_image.loading) {
-            var image = new Image();
-            image.src = "data:image/jpg;base64," + message.data;
-            image.onload = function() {
-              console.log('loaded image');
-              that._setImageSource(image.src);
-            }
-          } else {
-            console.log('Image is still loading, skip')
-          }
-        });
-      },
+        let updatingImage = false;
 
-      _setImageSource: function(data) {
-        this.image_source = data
+        this._imageTopic.subscribe(function(message) {
+          if (updatingImage) {
+            return;   // Drop frame if previous one didn't load yet.
+          }
+          updatingImage = true;
+          let image = new Image();
+          image.src = "data:image/jpg;base64," + message.data;
+          image.onload = function() {
+            const hRatio = canvas.width / image.width;
+            const vRatio = canvas.height / image.height;
+            const ratio  = Math.min (hRatio, vRatio);
+            context.drawImage(image, 0, 0,
+                              image.width, image.height,
+                              0, 0, image.width * ratio,
+                              image.height * ratio);
+            updatingImage = false;
+          };
+        });
       },
     });
   </script>

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -1,17 +1,29 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-image/iron-image.html">
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-listbox/paper-listbox.html">
 <link rel="import" href="imports.html">
 
 <dom-module id="ros-rviz-image">
   <template>
     <paper-input label="Image topic" value="{{topic}}"></paper-input>
     <paper-checkbox checked="{{continuous}}">Continuously update</paper-checkbox>
-    <paper-input label="Transport hints" value="{{transport_hints}}"></paper-input>
+    <paper-dropdown-menu id="transport_hints_list" label="Transport hints" on-iron-select="transportHintSelected">
+      <paper-listbox slot="dropdown-content" class="dropdown-content" selected="0">
+        <paper-item>Compressed</paper-item>
+        <paper-item>CompressedDepth</paper-item>
+      </paper-listbox>
+    </paper-dropdown-menu>
     <iron-image id="xy_image" src="[[image_source]]" alt="iron-image" ></iron-image>
   </template>
   <script>
+    const _transportHints = {
+      Compressed: {type: 'sensor_msgs/CompressedImage', topicSuffix: '/compressed'},
+      CompressedDepth: {type: 'sensor_msgs/CompressedImage', topicSuffix: '/compressedDepth'},
+    };
+
     Polymer({
       is: 'ros-rviz-image',
 
@@ -36,7 +48,7 @@
         },
         transport_hints: {
           type: String,
-          value: 'compressed',
+          value: 'Compressed',
           notify: true,
         },
         globalOptions: Object,
@@ -47,8 +59,13 @@
       },
 
       observers: [
-        '_optionsChanged(viewer, topic, continuous, transport_hints, ros)',
+        '_optionsChanged(viewer, topic, continuous, ros)',
       ],
+
+      transportHintSelected: function(e) {
+        this.transport_hints = this.$.transport_hints_list.selectedItemLabel;
+        this._optionsChanged();
+      },
 
       destroy: function() {
         // Nothing to destroy.
@@ -69,7 +86,7 @@
         }
       },
 
-      _optionsChanged: function(viewer, topic, continuous, transport_hints, ros) {
+      _optionsChanged: function(viewer, topic, continuous, ros) {
         this.hide();
         this._updateDisplay();
         this.show();
@@ -88,11 +105,10 @@
           this._imageTopic.unsubscribe();
         }
 
-        console.log('Creating image topic')
         this._imageTopic = new ROSLIB.Topic({
             ros : this.ros,
-            name : this.topic,
-            messageType : 'sensor_msgs/CompressedImage'
+            name : this.topic + _transportHints[this.transport_hints].topicSuffix,
+            messageType : _transportHints[this.transport_hints].type
         });
 
         this._imageTopic.subscribe(function(message) {

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -14,7 +14,11 @@
         <paper-item>CompressedDepth</paper-item>
       </paper-listbox>
     </paper-dropdown-menu>
-    <canvas id="xy_image" width="280px;" height="280px;"/>
+    <div style="position: relative;">
+      <div id="canvas_div" style="position: fixed; z-index: 9; border: 1px solid; background-color: black;">
+        <canvas id="xy_image" width="280px;" height="280px;"/>
+      </div>
+    </div>
   </template>
   <script>
     const _transportHints = {
@@ -53,6 +57,11 @@
       transportHintSelected: function(e) {
         this.transport_hints = this.$.transport_hints_dropdown.selectedItemLabel;
         this._optionsChanged();
+      },
+
+      ready: function() {
+        // Make the image DIV draggable.
+        this._dragImageDiv(this.$.canvas_div);
       },
 
       destroy: function() {
@@ -109,17 +118,56 @@
           let image = new Image();
           image.src = "data:image/jpg;base64," + message.data;
           image.onload = function() {
+            // Resize keeping ratio and center the image on the canvas.
             const hRatio = canvas.width / image.width;
             const vRatio = canvas.height / image.height;
-            const ratio  = Math.min (hRatio, vRatio);
-            context.drawImage(image, 0, 0,
-                              image.width, image.height,
-                              0, 0, image.width * ratio,
-                              image.height * ratio);
+            const ratio  = Math.min(hRatio, vRatio);
+            const centerShift_x = (canvas.width - image.width * ratio ) / 2;
+            const centerShift_y = (canvas.height - image.height * ratio ) / 2;
+            context.clearRect(0, 0, canvas.width, canvas.height);
+            context.drawImage(image, 0, 0, image.width, image.height,
+                              centerShift_x, centerShift_y,
+                              image.width * ratio, image.height * ratio);
             updatingImage = false;
           };
         });
       },
+
+      _dragImageDiv: function(imageDiv) {
+        // Reference: https://www.w3schools.com/howto/howto_js_draggable.asp.
+        var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+        imageDiv.onmousedown = dragMouseDown;
+
+        function dragMouseDown(e) {
+          e = e || window.event;
+          e.preventDefault();
+          // Get the mouse cursor position at startup:
+          pos3 = e.clientX;
+          pos4 = e.clientY;
+          document.onmouseup = closeDragElement;
+          // Call a function whenever the cursor moves:
+          document.onmousemove = elementDrag;
+        }
+
+        function elementDrag(e) {
+          e = e || window.event;
+          e.preventDefault();
+          // Calculate the new cursor position:
+          pos1 = pos3 - e.clientX;
+          pos2 = pos4 - e.clientY;
+          pos3 = e.clientX;
+          pos4 = e.clientY;
+          // Set the element's new position:
+          imageDiv.style.top = (imageDiv.offsetTop - pos2) + "px";
+          imageDiv.style.left = (imageDiv.offsetLeft - pos1) + "px";
+        }
+
+        function closeDragElement() {
+          // Stop moving when mouse button is released.
+          document.onmouseup = null;
+          document.onmousemove = null;
+        }
+    },
     });
   </script>
 </dom-module>

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -9,7 +9,6 @@
 <dom-module id="ros-rviz-image">
   <template>
     <paper-input label="Image topic" value="{{topic}}"></paper-input>
-    <paper-checkbox checked="{{continuous}}">Continuously update</paper-checkbox>
     <paper-dropdown-menu id="transport_hints_list" label="Transport hints" on-iron-select="transportHintSelected">
       <paper-listbox slot="dropdown-content" class="dropdown-content" selected="0">
         <paper-item>Compressed</paper-item>
@@ -37,11 +36,6 @@
           value: '/camera/image/compressed',
           notify: true,
         },
-        continuous: {
-          type: Boolean,
-          value: true,
-          notify: true,
-        },
         image_source: {
           type: String,
           value: '',
@@ -59,7 +53,7 @@
       },
 
       observers: [
-        '_optionsChanged(viewer, topic, continuous, ros)',
+        '_optionsChanged(viewer, topic, ros)',
       ],
 
       transportHintSelected: function(e) {
@@ -86,7 +80,7 @@
         }
       },
 
-      _optionsChanged: function(viewer, topic, continuous, ros) {
+      _optionsChanged: function(viewer, topic, ros) {
         this.hide();
         this._updateDisplay();
         this.show();
@@ -97,7 +91,6 @@
         var that = this;
 
         if (!(this.ros && this.viewer && this.topic &&
-             (this.continuous || this.continuous === false) &&
              (this.transport_hints))) {
           return;
         }

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -15,7 +15,7 @@
         <paper-item>CompressedDepth</paper-item>
       </paper-listbox>
     </paper-dropdown-menu>
-    <iron-image id="xy_image" src="[[image_source]]" alt="iron-image" ></iron-image>
+    <iron-image id="xy_image" src="[[image_source]]" alt="No image"/>
   </template>
   <script>
     const _transportHints = {
@@ -33,7 +33,7 @@
         },
         topic: {
           type: String,
-          value: '/camera/image/compressed',
+          value: '/camera/image',
           notify: true,
         },
         image_source: {
@@ -48,7 +48,6 @@
         globalOptions: Object,
         isShown: Boolean,
         ros: Object,
-        tfClient: Object,
         viewer: Object,
       },
 
@@ -87,7 +86,6 @@
       },
 
       _updateDisplay: function(callback) {
-        console.log('Image updating display')
         var that = this;
 
         if (!(this.ros && this.viewer && this.topic &&
@@ -105,9 +103,17 @@
         });
 
         this._imageTopic.subscribe(function(message) {
-          console.log('Received message on image viewer');
-          var imagedata = "data:image/jpg;base64," + message.data;
-          that._setImageSource(imagedata);
+          console.log('Received image');
+          if (!that.$.xy_image.loading) {
+            var image = new Image();
+            image.src = "data:image/jpg;base64," + message.data;
+            image.onload = function() {
+              console.log('loaded image');
+              that._setImageSource(image.src);
+            }
+          } else {
+            console.log('Image is still loading, skip')
+          }
         });
       },
 

--- a/ros-rviz-image.html
+++ b/ros-rviz-image.html
@@ -72,6 +72,7 @@
         if (this._imageTopic) {
           this._imageTopic.unsubscribe();
           this._imageTopic = null;
+          this.$.canvas_div.style.visibility = 'hidden';
         }
       },
 
@@ -80,6 +81,7 @@
           if (!this._imageTopic) {
             this._updateDisplay();
           }
+          this.$.canvas_div.style.visibility = 'visible';
         }
       },
 

--- a/ros-rviz.html
+++ b/ros-rviz.html
@@ -306,7 +306,7 @@ Example:
           isShown: true,
           name: 'Image',
           options: {
-            topic: '/camera/image/compressed',
+            topic: '/camera/image',
           },
           type: 'image',
         });

--- a/ros-rviz.html
+++ b/ros-rviz.html
@@ -121,6 +121,7 @@ Example:
                     on-tap="_onDisplaySelected">
                   <paper-item on-tap="addDepthCloud">Depth cloud</paper-item>
                   <paper-item on-tap="addGrid">Grid</paper-item>
+                  <paper-item on-tap="addImage">Image</paper-item>
                   <paper-item on-tap="addInteractiveMarkers">Interactive markers</paper-item>
                   <paper-item on-tap="addMarkers">Markers</paper-item>
                   <paper-item on-tap="addMarkerArray">Marker array</paper-item>
@@ -297,6 +298,17 @@ Example:
             numCells: 10,
           },
           type: 'grid',
+        });
+      },
+
+      addImage: function() {
+        this.push('config.displays', {
+          isShown: true,
+          name: 'Image',
+          options: {
+            topic: '/camera/image/compressed',
+          },
+          type: 'image',
         });
       },
 


### PR DESCRIPTION
This should address #6; a draggable image display is included as a new component. It supports compressed images so far.

See https://github.com/osrf/polymer-ros-rviz/pull/7 for details and discussion.

Here's a short example of the viewer using PR2 and gazebo:
![transparent_img](https://user-images.githubusercontent.com/5751272/48876681-3bebb780-edb4-11e8-942b-5d880f0b4787.gif)


